### PR TITLE
Allow kebab attributes without values

### DIFF
--- a/includecontents/templatetags/includecontents.py
+++ b/includecontents/templatetags/includecontents.py
@@ -84,9 +84,12 @@ def includecontents(parser, token):
                 # Nested attrs can't be handled by the standard include tag.
                 attr, value = match.groups()
                 advanced_attrs[attr] = parser.compile_filter(value or "True")
-            elif "-" in bit.split("=", 1)[0]:
+            elif "-" in bit:
                 # Attributes with a dash also can't be handled by the standard include.
-                attr, value = bit.split("=", 1)
+                parts = bit.split("=", 1)
+                if len(parts) < 2:
+                    parts.append("")
+                attr, value = parts
                 advanced_attrs[attr] = parser.compile_filter(value)
             elif match := re.match(r"^{ *(\w+) *}$", bit):
                 # Shorthand, e.g. {attr} is equivalent to attr=attr.

--- a/includecontents/templatetags/includecontents.py
+++ b/includecontents/templatetags/includecontents.py
@@ -90,7 +90,7 @@ def includecontents(parser, token):
                     attr, value = bit.split("=", 1)
                 else:
                     attr, value = bit, ""
-                advanced_attrs[attr] = parser.compile_filter(value)
+                advanced_attrs[attr] = parser.compile_filter(value or "True")
             elif match := re.match(r"^{ *(\w+) *}$", bit):
                 # Shorthand, e.g. {attr} is equivalent to attr=attr.
                 attr = match.group(1)

--- a/includecontents/templatetags/includecontents.py
+++ b/includecontents/templatetags/includecontents.py
@@ -86,10 +86,10 @@ def includecontents(parser, token):
                 advanced_attrs[attr] = parser.compile_filter(value or "True")
             elif "-" in bit:
                 # Attributes with a dash also can't be handled by the standard include.
-                parts = bit.split("=", 1)
-                if len(parts) < 2:
-                    parts.append("")
-                attr, value = parts
+                if "=" in bit:
+                    attr, value = bit.split("=", 1)
+                else:
+                    attr, value = bit, ""
                 advanced_attrs[attr] = parser.compile_filter(value)
             elif match := re.match(r"^{ *(\w+) *}$", bit):
                 # Shorthand, e.g. {attr} is equivalent to attr=attr.

--- a/tests/templates/test_component/attrs.html
+++ b/tests/templates/test_component/attrs.html
@@ -1,5 +1,5 @@
 <main>
-  <include:card title="hello" large id="topcard" class="mycard">
+  <include:card title="hello" large id="topcard" class="mycard" x-data>
     some content
   </include:card>
 </main>

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -28,7 +28,7 @@ def test_debug_mode():
 def test_attrs():
     assert render_to_string("test_component/attrs.html") == (
         """<main>
-  <section class="mycard" id="topcard">
+  <section class="mycard" id="topcard" x-data>
   <h3 class="large">hello</h3>
   <div>
     some content


### PR DESCRIPTION
Fixes a regression in > 0.7 versions  causing an exception to raise if a kebab-cased attribute does not have a value. E.g. `<include:foo x-data />`